### PR TITLE
DEV: Core feature spec refinement

### DIFF
--- a/spec/system/core_feature_spec.rb
+++ b/spec/system/core_feature_spec.rb
@@ -1,7 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe "Core features", type: :system do
+  fab!(:current_user) { Fabricate(:user, refresh_auto_groups: true) }
+  let(:composer) { PageObjects::Components::Composer.new }
+
   before { upload_theme }
+
   it_behaves_like "having working core features",
                   skip_examples: %i[topics:create search:quick_search]
+
+  it "creates a new topic" do
+    sign_in(current_user)
+    visit("/new-topic")
+    composer.fill_title("This is a new topic")
+    composer.fill_content("This is a long enough sentence.")
+    expect(page).to have_css(".d-editor-preview p", visible: true)
+    within(".save-or-cancel") { click_button("Create Topic") }
+    expect(page).to have_content("This is a new topic")
+    expect(page).to have_content("This is a long enough sentence.")
+  end
 end


### PR DESCRIPTION
Followup e4b99976ebbba6b96ba7a9dcd61740406057821d

This allows us to skip core feature specs more granularly,
since the topic ones work fine except create for example.

Also adds a topic create spec, since this theme uses the sidebar
new topic button component. We can rely on the /new-topic route
instead.
