### PR TITLE
UX: fix topic progress height

### DIFF
--- a/scss/topic.scss
+++ b/scss/topic.scss
@@ -6,7 +6,7 @@
   }
 }
 
-.container.posts .topic-navigation {
+.container.posts .topic-navigation:not(.with-topic-progress) {
   // super fragile because new sticky topic title doesnt have a calculated value (= 53px with this font and size but…)
   top: calc(
     var(--header-offset, 60px) + 53px + calc(var(--spacing-block-l) * 2)


### PR DESCRIPTION
Before: 
![image](https://github.com/user-attachments/assets/b41d9c5f-6a7a-4cae-aa87-375e54b94bf9)


After:
![image](https://github.com/user-attachments/assets/e6969dcd-83b3-4e3c-a868-1dbd70ecf195)
