### PR TITLE
UX: main-outlet needs dynamic bottom padding when composer open

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -62,8 +62,12 @@ body:not(.has-full-page-chat) {
     }
     #main-outlet {
       width: 100%;
-      padding-bottom: var(--spacing-block-l);
       max-width: unset;
+      padding-bottom: var(--spacing-block-l);
+      html.composer-open & {
+        padding-bottom: var(--composer-height);
+      }
+
       //thanks to random container elements on the page, I can't do a direct child selector here because it targets all the randomness, so I see no other option than MANUALLY adding every possible element that can appear in the main outlet YAY
       .list-controls,
       .list-container,

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -67,29 +67,7 @@ body:not(.has-full-page-chat) {
       html.composer-open & {
         padding-bottom: var(--composer-height);
       }
-
-      //thanks to random container elements on the page, I can't do a direct child selector here because it targets all the randomness, so I see no other option than MANUALLY adding every possible element that can appear in the main outlet YAY
-      .list-controls,
-      .list-container,
-      #topic-title,
-      .container.posts,
-      #topic-footer-buttons,
-      .more-topics__container,
-      .welcome-banner,
-      .reviewable,
-      .admin-content,
-      .discourse-post-event-upcoming-events,
-      .body-page,
-      .topic-above-footer-buttons-outlet .presence-users,
-      .global-notice,
-      .users-directory.directory,
-      .container .user-main,
-      .container.groups-index,
-      .container.badges,
-      .container.tags-index,
-      .container.group,
-      .container.cakeday,
-      .edit-category {
+      > * {
         @include breakpoint(medium, $rule: min-width) {
           box-sizing: border-box;
           max-width: 1000px;


### PR DESCRIPTION
When the composer is open the `#main-outlet`'s bottom padding needs to match the composer height, so the content behind the composer can be scrolled into view.

Reported here: https://meta.discourse.org/t/help-us-test-horizon-our-newest-theme/360484/26?u=awesomerobot