### PR TITLE
UX: font set experimental screen styles

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -64,7 +64,7 @@ body:not(.has-full-page-chat) {
       width: 100%;
       padding-bottom: var(--spacing-block-l);
       max-width: unset;
-      > * {
+      > *:not(.experimental-screen) {
         @include breakpoint(medium, $rule: min-width) {
           box-sizing: border-box;
           max-width: 1000px;


### PR DESCRIPTION
This PR fixes the experimental screen implementation. It was being broken by 

```
> * {
        @include breakpoint(medium, $rule: min-width) {
          box-sizing: border-box;
          max-width: 1000px;
          margin-inline: auto;
          padding-inline: var(--spacing-inline-l);
        }
```