### PR TITLE
UX: New PM design

### DIFF
--- a/javascripts/discourse/components/card/topic-replies-column.gjs
+++ b/javascripts/discourse/components/card/topic-replies-column.gjs
@@ -3,7 +3,7 @@ import gt from "truth-helpers/helpers/gt";
 
 const TopicRepliesColumn = <template>
   {{#if (gt @topic.replyCount 1)}}
-    <span class="topic-replies">{{icon "reply"}}{{@topic.replyCount}}</span>
+    <span class="topic-replies">{{icon "reply"}}{{@topic.posts_count}}</span>
   {{/if}}
 </template>;
 

--- a/javascripts/discourse/initializers/topic-list-columns.gjs
+++ b/javascripts/discourse/initializers/topic-list-columns.gjs
@@ -33,15 +33,12 @@ const TopicLikesReplies = <template>
 export default {
   name: "topic-list-customizations",
 
-  initialize() {
+  initialize(container) {
+    const router = container.lookup("service:router");
     withPluginApi("1.39.0", (api) => {
       api.registerValueTransformer(
         "topic-list-columns",
         ({ value: columns }) => {
-          columns.add("topic-activity", {
-            item: TopicActivity,
-            after: "title",
-          });
           columns.add("topic-status", {
             item: TopicStatus,
             after: "topic-author",
@@ -50,14 +47,21 @@ export default {
             item: TopicCategory,
             after: "topic-status",
           });
+
           columns.add("topic-likes-replies", {
             item: TopicLikesReplies,
             after: "topic-author-avatar",
           });
-          columns.delete("posters");
           columns.delete("views");
           columns.delete("replies");
-          columns.delete("activity");
+          if (!router.currentRouteName.includes("userPrivateMessages")) {
+            columns.add("topic-activity", {
+              item: TopicActivity,
+              after: "title",
+            });
+            columns.delete("posters");
+            columns.delete("activity");
+          }
           return columns;
         }
       );

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -530,46 +530,93 @@
 
 // User Messages
 
-body.user-messages-page .topic-list-item {
-  td.topic-category-data,
-  td.topic-likes-replies-data,
-  td.topic-status-data {
-    display: none;
+body.user-messages-page {
+  .topic-list-body {
+    gap: 0;
   }
-  td.main-link .link-top-line {
-    grid-row: 1 / 2;
-    grid-column: 1 / -1;
+  .topic-list .topic-list-data.posters a:not(.latest) {
+    display: block;
   }
-  grid-template-areas:
-    ". . . . . . ."
-    "activity . . . . likes-replies likes-replies";
-  &.excerpt-expanded {
-    grid-template-columns: 20px repeat(6, 1fr) auto;
-    grid-template-rows: 20px auto auto 30px;
-    grid-template-areas:
-      ". . . . . . . ."
-      "activity . . . . . . ."
-      "excerpt excerpt excerpt excerpt excerpt excerpt . ."
-      "excerpt excerpt excerpt excerpt excerpt excerpt likes-replies likes-replies";
-    @include breakpoint(extra-large) {
-      grid-template-areas:
-        ". . . . . . . ."
-        "activity . . . . . . ."
-        "excerpt excerpt excerpt excerpt excerpt excerpt . likes-replies"
-        "excerpt excerpt excerpt excerpt excerpt excerpt . likes-replies";
-    }
-  }
-  @include breakpoint(mobile-extra-large) {
-    grid-template-columns: 25px auto repeat(6, 1fr);
-    grid-template-rows: auto auto;
-    grid-template-areas:
-      ". . . . . . . ."
-      "activity . . . . . . .";
-    .topic-excerpt {
+  .topic-list-item {
+    border-radius: 0;
+    box-shadow: none;
+    border-bottom: 1px solid var(--primary-200);
+    border-top: none;
+    border-right: none;
+    border-left: none;
+    display: grid;
+    grid-template-areas: "title activity" "posters .";
+    grid-template-columns: min-content auto;
+    grid-template-rows: min-content;
+    td.topic-category-data,
+    td.topic-likes-replies-data,
+    td.topic-status-data {
       display: none;
+    }
+    &.visited .main-link .link-top-line {
+      font-weight: normal;
+      grid-area: title;
+    }
+    &:hover {
+      background-color: var(--primary-low);
+      border-color: var(--primary-200);
+    }
+    .link-top-line {
+      order: 1;
+      width: max-content;
+    }
+    td.topic-activity-data {
+      grid-area: activity;
+    }
+    td.topic-list-data.posters {
+      grid-area: posters;
+      display: flex;
+      align-items: center;
+      height: 100%;
+      .avatar {
+        width: 20px;
+        height: 20px;
+        border-radius: 4px;
+      }
     }
   }
 }
+
+// td.main-link .link-top-line {
+//   grid-row: 1 / 2;
+//   grid-column: 1 / -1;
+// }
+// grid-template-areas:
+//   ". posters posters"
+//   "activity posters posters";
+// grid-template-columns: min-content auto auto;
+// &.excerpt-expanded {
+//   grid-template-columns: 20px repeat(6, 1fr) auto;
+//   grid-template-rows: 20px auto auto 30px;
+//   grid-template-areas:
+//     ". . . . . . . ."
+//     "activity . . . . . . ."
+//     "excerpt excerpt excerpt excerpt excerpt excerpt . ."
+//     "excerpt excerpt excerpt excerpt excerpt excerpt posters posters";
+//   @include breakpoint(extra-large) {
+//     grid-template-areas:
+//       ". . . . . . . ."
+//       "activity . . . . . . ."
+//       "excerpt excerpt excerpt excerpt excerpt excerpt . posters"
+//       "excerpt excerpt excerpt excerpt excerpt excerpt . posters";
+//   }
+// }
+// @include breakpoint(mobile-extra-large) {
+//   grid-template-columns: 25px auto repeat(6, 1fr);
+//   grid-template-rows: auto auto;
+//   grid-template-areas:
+//     ". . . . . . . ."
+//     "activity . . . . . . .";
+//   .topic-excerpt {
+//     display: none;
+//   }
+// }
+// }
 
 // Bulk select
 

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -582,42 +582,6 @@ body.user-messages-page {
   }
 }
 
-// td.main-link .link-top-line {
-//   grid-row: 1 / 2;
-//   grid-column: 1 / -1;
-// }
-// grid-template-areas:
-//   ". posters posters"
-//   "activity posters posters";
-// grid-template-columns: min-content auto auto;
-// &.excerpt-expanded {
-//   grid-template-columns: 20px repeat(6, 1fr) auto;
-//   grid-template-rows: 20px auto auto 30px;
-//   grid-template-areas:
-//     ". . . . . . . ."
-//     "activity . . . . . . ."
-//     "excerpt excerpt excerpt excerpt excerpt excerpt . ."
-//     "excerpt excerpt excerpt excerpt excerpt excerpt posters posters";
-//   @include breakpoint(extra-large) {
-//     grid-template-areas:
-//       ". . . . . . . ."
-//       "activity . . . . . . ."
-//       "excerpt excerpt excerpt excerpt excerpt excerpt . posters"
-//       "excerpt excerpt excerpt excerpt excerpt excerpt . posters";
-//   }
-// }
-// @include breakpoint(mobile-extra-large) {
-//   grid-template-columns: 25px auto repeat(6, 1fr);
-//   grid-template-rows: auto auto;
-//   grid-template-areas:
-//     ". . . . . . . ."
-//     "activity . . . . . . .";
-//   .topic-excerpt {
-//     display: none;
-//   }
-// }
-// }
-
 // Bulk select
 
 .bulk-select-enabled .topic-list-body .topic-list-item {

--- a/spec/system/horizon_high_level_spec.rb
+++ b/spec/system/horizon_high_level_spec.rb
@@ -36,10 +36,10 @@ describe "Horizon theme | High level", type: :system do
     expect(topic_item.all("td").map { |el| el["class"] }).to eq(
       [
         "main-link topic-list-data",
-        "topic-activity-data",
         "topic-status-data",
         "topic-category-data",
         "topic-likes-replies-data",
+        "topic-activity-data",
       ],
     )
 


### PR DESCRIPTION
This PR restyles PMs in the Horizon theme to more closely match typical inbox layouts. It also adds back in posters so you can see who is participating in the PM.

**Before**
![CleanShot 2025-04-11 at 11 36 18@2x](https://github.com/user-attachments/assets/3f3e783d-9797-4a95-ba5a-c04c83262216)


**After**
![CleanShot 2025-04-11 at 11 36 41@2x](https://github.com/user-attachments/assets/0ef050cc-3a3e-4402-806c-7b8f2eaf106f)
