### PR TITLE
UX: adjust disabled create button tooltip styles

### DIFF
--- a/scss/sidebar-new-topic-button.scss
+++ b/scss/sidebar-new-topic-button.scss
@@ -34,6 +34,22 @@
       border-radius: 0 var(--d-button-border-radius)
         var(--d-button-border-radius) 0;
     }
+
+    .fk-d-button-tooltip:has(button[disabled]) {
+      + .topic-drafts-menu-trigger {
+        display: none;
+      }
+
+      .fk-d-tooltip__trigger {
+        background: var(--accent-color);
+        border-radius: 0 var(--d-button-border-radius)
+          var(--d-button-border-radius) 0;
+        padding-right: 0.65em;
+        .d-icon {
+          color: var(--secondary);
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Improves the disabled state of the new topic button in the sidebar by hiding the draft dropdown (which is inaccessible) and styling the tooltip like the end of the button

Before:
![image](https://github.com/user-attachments/assets/f3222602-a920-416f-ab35-ed175e720cda)

After: 
![image](https://github.com/user-attachments/assets/fa1e327b-0c4c-452b-add4-28f67a4a9d0e)
