### PR TITLE
UX: make theme compatible with AI gists

### DIFF
--- a/scss/misc.scss
+++ b/scss/misc.scss
@@ -69,8 +69,11 @@ input[type="color"]:focus,
   background-color: var(--background-color);
 }
 
-.fk-d-menu__trigger.topic-list-layout-trigger {
-  display: none;
+@include breakpoint(mobile-extra-large) {
+  // pinned topic excerpts are hidden on small screens too
+  .fk-d-menu__trigger.topic-list-layout-trigger {
+    display: none;
+  }
 }
 
 .search-container .search-header,

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -86,7 +86,8 @@
         "category category category category status"
         ". . . . ."
         "activity . . . likes-replies";
-      .topic-excerpt {
+      .topic-excerpt,
+      .link-bottom-line {
         display: none;
       }
     }
@@ -98,6 +99,9 @@
     }
     .badge-category__wrapper {
       height: min-content;
+    }
+    .link-bottom-line {
+      display: flex;
     }
   }
 
@@ -233,14 +237,6 @@
     min-width: unset;
   }
 
-  // excerpt
-  .topic-excerpt {
-    grid-row: 3 / -1;
-    grid-column: 1 / -3;
-    margin: 0;
-    font-size: var(--font-down-2);
-  }
-
   // timestamp
   td.activity .post-activity {
     grid-area: activity;
@@ -250,10 +246,27 @@
     padding: 0;
   }
 
-  // metadata
-  // metadata - category
-  td.main-link .link-bottom-line {
+  .link-bottom-line {
     display: none;
+  }
+
+  // metadata
+  // metadata - excerpt
+  .topic-excerpt,
+  td.main-link .link-bottom-line {
+    grid-row: 3 / -1;
+    grid-column: 1 / -3;
+    margin: 0;
+    font-size: var(--font-down-2);
+
+    .excerpt__contents {
+      color: var(--primary-high);
+    }
+
+    // default category position hidden
+    .badge-category__wrapper {
+      display: none;
+    }
   }
 
   td.topic-category-status-data {


### PR DESCRIPTION
Before (only pinned topic excerpts, no gist toggle):
![image](https://github.com/user-attachments/assets/7a1b78b8-e115-4c96-9ebf-52d2c1237eea)


After (gists can be toggled on): 
![image](https://github.com/user-attachments/assets/9e6786be-3817-4420-8142-1c5f7cad54ea)


This puts the gists in the same place as the theme places excerpts and uses the same styles. It also follows the theme pattern of hiding excerpts/gists on mobile. 