### PR TITLE
UX: minor breakpoint gap fix

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -58,7 +58,7 @@ body:not(.has-full-page-chat) {
     @include breakpoint(medium) {
       --main-grid-gap: 0;
     }
-    @include breakpoint(tablet, $rule: min-width) {
+    @media screen and (min-width: 768px) {
       gap: var(--main-grid-gap);
     }
     #main-outlet {


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/help-us-test-horizon-our-newest-theme/360484/55?u=awesomerobot

We have a 1px gap here where we get kind of a half-container 

Before:
![image](https://github.com/user-attachments/assets/0d355156-c579-418d-a1d1-9d624c61bc12)



After:
![image](https://github.com/user-attachments/assets/ce96bf6b-c8a8-4fd2-b5b0-56d37382284d)
