### PR TITLE
UX: text logo line-height fix

### DIFF
--- a/scss/desktop-full-width.scss
+++ b/scss/desktop-full-width.scss
@@ -32,7 +32,7 @@ $sidebar-width: 17em;
   font-size: clamp(var(--font-0), 2.5vw, var(--font-up-2));
   .has-sidebar-page & {
     white-space: wrap;
-    line-height: var(--line-height-small);
+    line-height: var(--line-height-medium);
     @include line-clamp(2);
   }
 }


### PR DESCRIPTION
Minor adjustment to avoid clipping descenders 


before:
![image](https://github.com/user-attachments/assets/bc68416b-ab04-4a62-8bff-ec8164284380)


after: 
![image](https://github.com/user-attachments/assets/30296e9c-4e8d-446f-8ee4-f0583e6c3e68)
