### PR TITLE
UX: fix experimental new new positioning

### DIFF
--- a/scss/desktop-horizon-fixes.scss
+++ b/scss/desktop-horizon-fixes.scss
@@ -39,8 +39,6 @@
     }
 
     &.default {
-      position: absolute;
-      right: 0;
       .bulk-select,
       span:not(.bulk-select-topics, .d-button-label) {
         display: none;


### PR DESCRIPTION
These styles were added for bulk select positioning, but turns out they weren't needed anyway 

before:
![image](https://github.com/user-attachments/assets/bf752846-cb51-4872-9cb7-2d98ab7f5c8f)

after:
![image](https://github.com/user-attachments/assets/4a25c776-b88c-4be6-b186-31973c6b5e05)
