### PR TITLE
UX: New topic button shouldn't appear in AI conversations page

### DIFF
--- a/scss/buttons.scss
+++ b/scss/buttons.scss
@@ -58,7 +58,8 @@
 }
 
 .btn-primary,
-#create-topic.btn {
+#create-topic.btn,
+.discourse-no-touch .btn-default.ai-new-question-button {
   background-color: var(--accent-color);
   color: var(--accent-text-color);
   .d-icon {

--- a/scss/sidebar-new-topic-button.scss
+++ b/scss/sidebar-new-topic-button.scss
@@ -5,6 +5,12 @@
   }
 }
 
+.has-ai-conversations-sidebar {
+  .sidebar-new-topic-button__wrapper {
+    display: none;
+  }
+}
+
 .sidebar-new-topic-button {
   flex: 1 1 auto;
 


### PR DESCRIPTION
## :mag: Overview
This update ensures that the sidebar new topic button isn't shown on the AI conversations sidebar. It also styles the new conversation button to make use of Horizon's accent color

## 📸 Screenshots

### ← Before
<img width="1228" alt="Screenshot 2025-05-02 at 14 16 41" src="https://github.com/user-attachments/assets/b187d31e-881a-4c34-b663-f4b55b8bc565" />

### → After
<img width="1232" alt="Screenshot 2025-05-02 at 14 15 34" src="https://github.com/user-attachments/assets/987cfba3-ad7c-49a9-80d8-14c3e52dd5c0" />
