### PR TITLE
UX: hide bootstrap mode from header

### DIFF
--- a/scss/desktop-full-width.scss
+++ b/scss/desktop-full-width.scss
@@ -154,7 +154,7 @@ $sidebar-width: 17em;
 
   .d-header-mode {
     .bootstrap-mode {
-      margin: 0;
+      display: none;
     }
   }
 


### PR DESCRIPTION
There are multiple header elements that get in the way, and we can't really manage the position of this button well without a better full-width solution... so I think it makes sense to hide it for now 


Before:
![image](https://github.com/user-attachments/assets/07009232-d188-4a5f-9381-0e1d4479512b)

After: 
![image](https://github.com/user-attachments/assets/91a0f01a-3d12-4f89-9d7f-0050abdd47e9)
