### PR TITLE
UX: exclude wizard from #main-outlet background styling

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -50,7 +50,7 @@ body:not(.has-sidebar-page) #main-outlet-wrapper {
   }
 }
 
-body:not(.has-full-page-chat) {
+body:not(.has-full-page-chat, .wizard) {
   @include breakpoint(extra-large, $rule: min-width) {
     background-color: var(--background-color);
   }


### PR DESCRIPTION
Only a tiny sliver of the background shows currently, which seems accidental 

Before:
![image](https://github.com/user-attachments/assets/815b9dec-7708-44a1-b360-7394e42cc4f6)


After:
![image](https://github.com/user-attachments/assets/b2eaf893-3e41-4321-b836-873b691589c5)
