### PR TITLE
UX: handle opening composer from slide-in hamburger menu

### DIFF
--- a/javascripts/discourse/api-initializers/hamburger-click-outside-transformer.js
+++ b/javascripts/discourse/api-initializers/hamburger-click-outside-transformer.js
@@ -1,0 +1,10 @@
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer("0.8", (api) => {
+  api.registerValueTransformer(
+    "hamburger-dropdown-click-outside-exceptions",
+    ({ value }) => {
+      return [...value, ".topic-drafts-menu-content"];
+    }
+  );
+});

--- a/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -68,7 +68,6 @@ export default class SidebarNewTopicButton extends Component {
 
   @action
   createNewTopic() {
-    this.closeHamburger();
     this.composer.openNewTopic({ category: this.category, tags: this.tag?.id });
   }
 

--- a/javascripts/discourse/components/sidebar-new-topic-button.gjs
+++ b/javascripts/discourse/components/sidebar-new-topic-button.gjs
@@ -3,6 +3,7 @@ import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import didUpdate from "@ember/render-modifiers/modifiers/did-update";
+import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
 import { gt } from "truth-helpers";
 import CreateTopicButton from "discourse/components/create-topic-button";
@@ -13,6 +14,8 @@ export default class SidebarNewTopicButton extends Component {
   @service currentUser;
   @service siteSettings;
   @service router;
+  @service header;
+  @service appEvents;
 
   @tracked category;
   @tracked tag;
@@ -65,6 +68,7 @@ export default class SidebarNewTopicButton extends Component {
 
   @action
   createNewTopic() {
+    this.closeHamburger();
     this.composer.openNewTopic({ category: this.category, tags: this.tag?.id });
   }
 
@@ -74,12 +78,30 @@ export default class SidebarNewTopicButton extends Component {
     this.tag = this.router.currentRoute.attributes?.tag || null;
   }
 
+  @action
+  watchForComposer() {
+    // this covers opening drafts from the hamburger menu
+    this.appEvents.on("composer:will-open", this, this.closeHamburger);
+  }
+
+  @action
+  stopWatchingForComposer() {
+    this.appEvents.off("composer:will-open", this, this.closeHamburger);
+  }
+
+  @action
+  closeHamburger() {
+    this.header.hamburgerVisible = false;
+  }
+
   <template>
     {{#if this.shouldRender}}
       <div
         class="sidebar-new-topic-button__wrapper"
         {{didInsert this.getCategoryandTag}}
         {{didUpdate this.getCategoryandTag this.router.currentRoute}}
+        {{didInsert this.watchForComposer}}
+        {{willDestroy this.stopWatchingForComposer}}
       >
         <CreateTopicButton
           @canCreateTopic={{this.canCreateTopic}}

--- a/scss/sidebar.scss
+++ b/scss/sidebar.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .sidebar-wrapper,
 .sidebar-hamburger-dropdown {
   @include breakpoint(medium) {
@@ -78,5 +80,14 @@
 
   .sidebar-new-topic-button .d-icon {
     display: none;
+  }
+}
+
+// put the draft menu above the slide-out hamburger on small desktop screens
+@include viewport.until(md) {
+  body:not(.mobile-view) {
+    .topic-drafts-menu-content {
+      z-index: z("header") + 1;
+    }
   }
 }

--- a/scss/sidebar.scss
+++ b/scss/sidebar.scss
@@ -85,9 +85,9 @@
 
 // put the draft menu above the slide-out hamburger on small desktop screens
 @include viewport.until(md) {
-  body:not(.mobile-view) {
+  html:not(.mobile-view) {
     .topic-drafts-menu-content {
-      z-index: z("header") + 1;
+      z-index: z("modal", "overlay");
     }
   }
 }


### PR DESCRIPTION
We need to close the slide-in hamburger menu on mobile when new topic or a draft is opened from it, this should do it! 