### PR TITLE
FIX: do not error when no palettes are available

### DIFF
--- a/javascripts/discourse/components/user-color-palette-selector.gjs
+++ b/javascripts/discourse/components/user-color-palette-selector.gjs
@@ -37,8 +37,8 @@ export default class UserColorPaletteSelector extends Component {
   @tracked cssLoaded = true;
 
   get userColorPalettes() {
-
-    const availablePalettes = listColorSchemes(this.site)?.map((userPalette) => {
+    const availablePalettes = listColorSchemes(this.site)
+      ?.map((userPalette) => {
         return {
           ...userPalette,
           accent: `#${

--- a/javascripts/discourse/components/user-color-palette-selector.gjs
+++ b/javascripts/discourse/components/user-color-palette-selector.gjs
@@ -37,8 +37,8 @@ export default class UserColorPaletteSelector extends Component {
   @tracked cssLoaded = true;
 
   get userColorPalettes() {
-    const availablePalettes = listColorSchemes(this.site)
-      .map((userPalette) => {
+
+    const availablePalettes = listColorSchemes(this.site)?.map((userPalette) => {
         return {
           ...userPalette,
           accent: `#${
@@ -56,7 +56,7 @@ export default class UserColorPaletteSelector extends Component {
     // Match the light scheme with the corresponding dark id based in the name
     return (
       availablePalettes
-        .map((palette) => {
+        ?.map((palette) => {
           if (palette.is_dark) {
             return palette;
           }


### PR DESCRIPTION
To repro this you had to unchecked all the "Color palette can be selected by users" from the colors tab.