### PR TITLE
Chat drawer and peakmode

### DIFF
--- a/scss/chat.scss
+++ b/scss/chat.scss
@@ -32,7 +32,7 @@ body.has-full-page-chat {
     right: var(--main-grid-gap);
 
     &:has(.is-expanded) {
-      z-index: 701;
+      z-index: calc(z("composer", "dropdown") + 1);
     }
   }
 }

--- a/scss/chat.scss
+++ b/scss/chat.scss
@@ -27,7 +27,7 @@ body.has-full-page-chat {
   .peek-mode-active & {
     padding-bottom: 0;
     left: unset;
-    right: 0;
+    right: var(--main-grid-gap);
     &:has(.is-expanded) {
       z-index: 701;
     }

--- a/scss/chat.scss
+++ b/scss/chat.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .full-page-chat.full-page-chat-sidebar-enabled {
   border: none;
 }
@@ -74,7 +76,7 @@ body.has-full-page-chat {
 }
 
 .chat-replying-indicator-container {
-  @include breakpoint("mobile-extra-large") {
+  @include viewport.from(sm) {
     margin-left: calc(0.65em + 0.2rem);
   }
 }

--- a/scss/chat.scss
+++ b/scss/chat.scss
@@ -23,6 +23,21 @@ body.has-full-page-chat {
 
 .chat-drawer-outlet-container {
   z-index: z("composer", "content");
+
+  .peek-mode-active & {
+    padding-bottom: 0;
+    left: unset;
+    right: 0;
+    &:has(.is-expanded) {
+      z-index: 701;
+    }
+  }
+}
+
+.chat-drawer {
+  .peek-mode-active & {
+    max-width: 90vw;
+  }
 }
 
 .chat-drawer .channels-list-container .chat-channel-row {
@@ -55,4 +70,10 @@ body.has-full-page-chat {
 
 .chat-drawer-active.chat-drawer-expanded .chat-composer-dropdown__menu-content {
   z-index: z("composer", "content") + 1;
+}
+
+.chat-replying-indicator-container {
+  @include breakpoint("mobile-extra-large") {
+    margin-left: calc(0.65em + 0.2rem);
+  }
 }

--- a/scss/chat.scss
+++ b/scss/chat.scss
@@ -28,6 +28,7 @@ body.has-full-page-chat {
     padding-bottom: 0;
     left: unset;
     right: var(--main-grid-gap);
+
     &:has(.is-expanded) {
       z-index: 701;
     }

--- a/scss/composer.scss
+++ b/scss/composer.scss
@@ -19,6 +19,8 @@
 
     .grippie {
       background: var(--tertiary-low);
+      border-top-right-radius: var(--d-border-radius);
+      border-top-left-radius: var(--d-border-radius);
     }
 
     .user-selector,


### PR DESCRIPTION
To avoid very strange positioning and sizing, I'm opting to keep the chat in front of the composer, when in peak-mode.
Still not ideal, but better than before.

![CleanShot 2025-05-14 at 13 11 16@2x](https://github.com/user-attachments/assets/9b28f097-a63b-4bbb-a016-68cbcd04ee3c)
⬇️ 
![CleanShot 2025-05-14 at 13 10 57@2x](https://github.com/user-attachments/assets/10b9c17e-1207-4775-8933-0f6aca8c3ab6)

Due to the way peakmode positions itself, it's impossible to place the chat flush next to it. And due to the way resizing works (frop the top left, anchored right), it also can't be placed on any left-handed alignment.