### PR TITLE
UX: make entire topic card clickable

### DIFF
--- a/javascripts/discourse/api-initializers/clickable-topic-row.js
+++ b/javascripts/discourse/api-initializers/clickable-topic-row.js
@@ -1,0 +1,41 @@
+import { apiInitializer } from "discourse/lib/api";
+import { wantsNewWindow } from "discourse/lib/intercept-click";
+
+export default apiInitializer((api) => {
+  api.registerBehaviorTransformer(
+    "topic-list-item-click",
+    ({ context, next }) => {
+      const event = context.event;
+      const target = event.target;
+      const topic = context.topic;
+
+      const excludedSelectors = [
+        "a:not(.title)",
+        "button",
+        ".bulk-select",
+        ".topic-category-data",
+      ];
+
+      const isExcluded = excludedSelectors.some((selector) =>
+        target.closest(selector)
+      );
+
+      if (isExcluded) {
+        return next();
+      }
+
+      const mainLink = target.closest(".title, .main-link, .topic-list-item");
+      if (mainLink) {
+        if (wantsNewWindow(event)) {
+          window.open(topic.lastUnreadUrl, "_blank");
+        } else {
+          event.preventDefault();
+          context.navigateToTopic(topic, topic.lastUnreadUrl);
+        }
+        return;
+      }
+
+      next();
+    }
+  );
+});

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -359,6 +359,7 @@
 }
 
 .topic-list-item {
+  cursor: pointer;
   background: var(--d-content-background);
   box-shadow: 0 0 12px 1px var(--topic-card-shadow);
 


### PR DESCRIPTION
Currently you can only click on the topic title, but we outline the entire card on hover regardless 

![image](https://github.com/user-attachments/assets/0624bf34-32e9-46b1-8996-16eca6dcaced)

This makes all the content of the card clickable to open the topic, except for some selectors like non-title links (categories, featured links), buttons, and bulk-select checkboxes