### PR TITLE
UX: fix low z-index for popup after changes to composer-drawer interaction

### DIFF
--- a/scss/chat.scss
+++ b/scss/chat.scss
@@ -72,7 +72,7 @@ body.has-full-page-chat {
 }
 
 .chat-drawer-active.chat-drawer-expanded .chat-composer-dropdown__menu-content {
-  z-index: z("composer", "content") + 1;
+  z-index: z("modal", "dialog");
 }
 
 .chat-replying-indicator-container {


### PR DESCRIPTION
Fixing:
![CleanShot 2025-05-20 at 11 58 11@2x](https://github.com/user-attachments/assets/68611ead-71bf-42bf-bd87-183f589f4b82)

Consequence of #161 