### PR TITLE
UX: adjust event date alignment with topic titles

### DIFF
--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -720,15 +720,8 @@ body.user-messages-page {
   }
 }
 
-.mobile-view {
-  .link-top-line .event-date-container {
-    display: inline;
-    margin-top: 0;
-  }
-
-  .topic-list-body .topic-list-item .link-top-line .event-date {
-    position: relative;
-    margin-left: 0;
-    top: -0.125em;
-  }
+.event-date-container {
+  display: inline-flex;
+  position: relative;
+  top: -0.25em; // optical alignment
 }


### PR DESCRIPTION
this regressed slightly with core changes 

before:
![image](https://github.com/user-attachments/assets/550df0f8-fb8d-4af3-b4ec-5a61834d8a45)


after:
![image](https://github.com/user-attachments/assets/5c06f32d-ee31-444e-90f7-c31f9c44f642)
