### PR TITLE
UX: fix new topic badge in topic list

### DIFF
--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -256,6 +256,10 @@
     min-width: unset;
   }
 
+  .badge-notification.new-topic::before {
+    display: none;
+  }
+
   // timestamp
   td.activity .post-activity {
     grid-area: activity;


### PR DESCRIPTION
The theme implements this in a centralized way, so we need to remove the core implementation. 

before:

![image](https://github.com/user-attachments/assets/a9b37f79-d464-43e9-9298-3607180162ec)


after:

![image](https://github.com/user-attachments/assets/bd3c79b5-6371-4439-86a2-5f91e44f04ca)
