### PR TITLE
UX: Topic cards v2

### DIFF
--- a/javascripts/discourse/components/card/topic-activity-column.gjs
+++ b/javascripts/discourse/components/card/topic-activity-column.gjs
@@ -26,13 +26,19 @@ export default class TopicActivityColumn extends Component {
         class: "--replied",
       };
     } else if (this.args.topic.posts_count === 1) {
+      return {
+        user: this.args.topic.firstPosterUser,
+        username: this.args.topic.last_poster_username,
+        class: "--created",
+      };
+    } else {
       return;
     }
   }
 
   <template>
     <span class={{concatClass "topic-activity" this.topicUser.class}}>
-      <div class="topic-activity__user">
+      <div class="topic-activity__type">
         {{#if this.topicUser.user}}
           {{icon "reply"}}
         {{else}}
@@ -44,24 +50,11 @@ export default class TopicActivityColumn extends Component {
         <span
           class="topic-activity__username"
         >{{this.topicUser.username}}</span>
-      {{/if}}
-
-      {{#if this.topicUser.user}}
-        {{#if this.site.mobileView}}
-          <span class="dot-separator"></span>
-        {{else}}
-          <div class="topic-activity__reason">
-            {{i18n (themePrefix this.topicUser.activityText)}}
-          </div>
-        {{/if}}
+        <span class="dot-separator"></span>
       {{/if}}
 
       <div class="topic-activity__time">
-        {{formatDate
-          @topic.bumpedAt
-          leaveAgo="true"
-          format="medium-with-ago-and-on"
-        }}
+        {{formatDate @topic.bumpedAt leaveAgo="true" format="tiny"}}
       </div>
     </span>
   </template>

--- a/javascripts/discourse/components/card/topic-activity-column.gjs
+++ b/javascripts/discourse/components/card/topic-activity-column.gjs
@@ -26,12 +26,7 @@ export default class TopicActivityColumn extends Component {
         class: "--replied",
       };
     } else if (this.args.topic.posts_count === 1) {
-      return {
-        user: this.args.topic.creator,
-        username: this.args.topic.creator.username,
-        activityText: "user_posted",
-        class: "--posted",
-      };
+      return;
     }
   }
 
@@ -39,19 +34,28 @@ export default class TopicActivityColumn extends Component {
     <span class={{concatClass "topic-activity" this.topicUser.class}}>
       <div class="topic-activity__user">
         {{#if this.topicUser.user}}
-          {{avatar this.topicUser.user imageSize="small"}}
+          {{icon "reply"}}
         {{else}}
           {{icon "pencil"}}
         {{/if}}
       </div>
+
       {{#if this.topicUser.username}}
         <span
           class="topic-activity__username"
         >{{this.topicUser.username}}</span>
       {{/if}}
-      <div class="topic-activity__reason">
-        {{i18n (themePrefix this.topicUser.activityText)}}
-      </div>
+
+      {{#if this.topicUser.user}}
+        {{#if this.site.mobileView}}
+          <span class="dot-separator"></span>
+        {{else}}
+          <div class="topic-activity__reason">
+            {{i18n (themePrefix this.topicUser.activityText)}}
+          </div>
+        {{/if}}
+      {{/if}}
+
       <div class="topic-activity__time">
         {{formatDate
           @topic.bumpedAt

--- a/javascripts/discourse/components/card/topic-activity-column.gjs
+++ b/javascripts/discourse/components/card/topic-activity-column.gjs
@@ -1,9 +1,7 @@
 import Component from "@glimmer/component";
-import avatar from "discourse/helpers/avatar";
 import concatClass from "discourse/helpers/concat-class";
 import icon from "discourse/helpers/d-icon";
 import formatDate from "discourse/helpers/format-date";
-import { i18n } from "discourse-i18n";
 
 export default class TopicActivityColumn extends Component {
   get topicUser() {

--- a/javascripts/discourse/components/card/topic-creator-column.gjs
+++ b/javascripts/discourse/components/card/topic-creator-column.gjs
@@ -1,0 +1,19 @@
+import Component from "@glimmer/component";
+import avatar from "discourse/helpers/avatar";
+
+export default class TopicActivityColumn extends Component {
+  get topicCreator() {
+    return {
+      user: this.args.topic.creator,
+      username: this.args.topic.creator.username,
+      class: "--topic-creator",
+    };
+  }
+
+  <template>
+    <div class={{this.topicUser.class}}>
+      {{avatar this.topicCreator.user}}
+      <span class="topic-activity__username">{{this.topicUser.username}}</span>
+    </div>
+  </template>
+}

--- a/javascripts/discourse/components/card/topic-creator-column.gjs
+++ b/javascripts/discourse/components/card/topic-creator-column.gjs
@@ -13,7 +13,7 @@ export default class TopicActivityColumn extends Component {
   <template>
     <div class={{this.topicUser.class}}>
       {{avatar this.topicCreator.user}}
-      <span class="topic-activity__username">{{this.topicUser.username}}</span>
+      <span class="topic-creator__username">{{this.topicUser.username}}</span>
     </div>
   </template>
 }

--- a/javascripts/discourse/components/card/topic-creator-column.gjs
+++ b/javascripts/discourse/components/card/topic-creator-column.gjs
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
 import avatar from "discourse/helpers/avatar";
 
-export default class TopicActivityColumn extends Component {
+export default class TopicCreatorColumn extends Component {
   get topicCreator() {
     return {
       user: this.args.topic.creator,

--- a/javascripts/discourse/initializers/topic-list-columns.gjs
+++ b/javascripts/discourse/initializers/topic-list-columns.gjs
@@ -32,7 +32,7 @@ const TopicLikesReplies = <template>
 </template>;
 
 const TopicCreator = <template>
-  <td class="topic-creator">
+  <td class="topic-creator-data">
     <TopicCreatorColumn @topic={{@topic}} />
   </td>
 </template>;

--- a/javascripts/discourse/initializers/topic-list-columns.gjs
+++ b/javascripts/discourse/initializers/topic-list-columns.gjs
@@ -1,6 +1,7 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
 import TopicActivityColumn from "../components/card/topic-activity-column";
 import TopicCategoryColumn from "../components/card/topic-category-column";
+import TopicCreatorColumn from "../components/card/topic-creator-column";
 import TopicLikesColumn from "../components/card/topic-likes-column";
 import TopicRepliesColumn from "../components/card/topic-replies-column";
 import TopicStatusColumn from "../components/card/topic-status-column";
@@ -30,6 +31,12 @@ const TopicLikesReplies = <template>
   </td>
 </template>;
 
+const TopicCreator = <template>
+  <td class="topic-creator">
+    <TopicCreatorColumn @topic={{@topic}} />
+  </td>
+</template>;
+
 export default {
   name: "topic-list-customizations",
 
@@ -50,6 +57,10 @@ export default {
 
           columns.add("topic-likes-replies", {
             item: TopicLikesReplies,
+            after: "topic-author-avatar",
+          });
+          columns.add("topic-creator", {
+            item: TopicCreator,
             after: "topic-author-avatar",
           });
           columns.delete("views");

--- a/scss/desktop-horizon-fixes.scss
+++ b/scss/desktop-horizon-fixes.scss
@@ -1,8 +1,8 @@
 // Fixing bulk select (only needed for desktop)
 .bulk-select-enabled {
-  .topic-list-header .topic-list-data.default {
-    position: sticky;
-    top: 10em;
+  .topic-list-header {
+    position: relative;
+    top: 0;
   }
 
   .topic-author-avatar-data {
@@ -47,19 +47,19 @@
     }
   }
 
+  //bulk select
   .bulk-select-topics {
     position: absolute;
-    right: -1em;
+    right: 0;
     background: var(--secondary);
     border-radius: 0 0 0 var(--d-border-radius);
-    padding: 1em;
-
-    @media screen and (max-width: 1048px) {
-      right: 0;
-    }
+    display: flex;
+    gap: 0.5rem;
+    margin: 0.5rem;
 
     button {
       white-space: nowrap;
+      margin: 0;
     }
   }
 }

--- a/scss/desktop-horizon-fixes.scss
+++ b/scss/desktop-horizon-fixes.scss
@@ -47,7 +47,7 @@
     }
   }
 
-  //bulk select
+  // bulk select
   .bulk-select-topics {
     position: absolute;
     right: 0;

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -97,6 +97,10 @@ body:not(.has-full-page-chat, .wizard) {
 }
 
 #list-area {
+  .contents {
+    max-width: 100%;
+    overflow: hidden;
+  }
   .show-more.has-topics {
     @include breakpoint(medium, $rule: min-width) {
       width: auto;

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -97,10 +97,6 @@ body:not(.has-full-page-chat, .wizard) {
 }
 
 #list-area {
-  .contents {
-    max-width: 100%;
-    overflow: hidden;
-  }
   .show-more.has-topics {
     @include breakpoint(medium, $rule: min-width) {
       width: auto;

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -1,3 +1,5 @@
+@use "lib/viewport";
+
 .topic-list .topic-list-item-separator {
   display: none;
 }
@@ -32,44 +34,21 @@
   padding: 0.75em 1rem;
   border: 1px solid var(--primary-300);
   display: grid;
-  grid-template-columns: min-content min-content min-content auto min-content;
-  grid-template-rows: auto minmax(20px, auto);
+  grid-template-columns: min-content min-content auto min-content;
   grid-template-areas:
-    "creator title title title status"
-    "creator category activity likes-replies .";
+    "creator title title status"
+    "creator category activity likes-replies";
   grid-column-gap: 0.75rem;
   grid-row-gap: 0.5rem;
   border-radius: var(--d-border-radius);
   cursor: pointer;
 
-  td.main-link .link-top-line {
-    // grid-column: 3/-1;
-    grid-area: title;
-    font-weight: 500;
-  }
-
-  &.--has-status-card td.main-link .link-top-line {
-    // grid-column: 3/-2;
-  }
-
-  @include breakpoint(extra-large) {
+  @include viewport.until(sm) {
     grid-template-areas:
-      ". . . . status"
-      "activity . . likes-replies category";
-  }
-
-  @include breakpoint(mobile-extra-large) {
-    td.main-link .link-top-line,
-    &.--has-status-card td.main-link .link-top-line {
-      grid-row: 2/3;
-      grid-column: 1/-1;
-    }
-    grid-template-columns: 20px repeat(5, 1fr);
-    grid-template-rows: auto auto auto;
-    grid-template-areas:
-      "category category category category category status"
-      ". . . . . ."
-      "activity . . . . likes-replies";
+      "category category category status"
+      "creator title title title"
+      "activity activity activity likes-replies";
+    row-gap: 0.75em;
     border: none;
     border-bottom: 1px solid var(--primary-200);
     box-shadow: none;
@@ -77,49 +56,38 @@
   }
 
   &.excerpt-expanded {
-    grid-template-columns: 20px auto auto min-content min-content;
-    grid-template-rows: auto auto auto auto;
-    grid-template-areas:
-      "category category . . status"
-      "title title title title title"
-      "activity . . . ."
-      "excerpt excerpt excerpt excerpy likes-replies";
-
-    // @include breakpoint(extra-large) {
-    //   grid-template-areas:
-    //     "category category . . status"
-    //     "activity . . . ."
-    //     "excerpt excerpt excerpt excerpt likes-replies";
-    // }
-
-    @include breakpoint(mobile-extra-large) {
-      grid-template-rows: auto auto auto;
-      grid-template-areas:
-        "category category category category status"
-        ". . . . ."
-        "activity . . . likes-replies";
-
+    @include viewport.until(sm) {
       .topic-excerpt,
       .link-bottom-line {
         display: none;
       }
     }
 
-    .topic-likes-replies-data {
-      align-self: flex-end;
+    @include viewport.from(sm) {
+      grid-template-areas:
+        "creator title title status"
+        "creator category activity likes-replies "
+        "creator excerpt excerpt excerpt";
     }
 
-    .topic-category-data {
-      align-items: flex-end;
+    //when there is enough space, excerpt can be next to likes-replies
+    @include viewport.from(lg) {
+      grid-template-areas:
+        "creator title title status"
+        "creator category activity ."
+        "creator excerpt excerpt likes-replies";
     }
+  }
 
-    .badge-category__wrapper {
-      height: min-content;
-    }
+  .badge-category__wrapper {
+    height: min-content;
+  }
 
-    .link-bottom-line {
-      display: flex;
-    }
+  .link-top-line {
+    grid-area: title;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
   }
 
   // display contents
@@ -127,12 +95,25 @@
   td.posters,
   td.posts,
   td.views,
-  td.activity {
+  td.activity,
+  td.topic-category-status-data {
     display: contents;
   }
 
   td.num.posts a {
     padding: 0;
+  }
+
+  //display:nones
+  td.main-link a.topic-status,
+  .link-bottom-line,
+  .badge-notification.new-topic::before {
+    display: none;
+  }
+
+  .topic-category-data {
+    grid-area: category;
+    display: flex;
   }
 
   //OP avatar
@@ -143,56 +124,56 @@
       height: 50px;
       width: 50px;
       border-radius: var(--d-border-radius);
+
+      @include viewport.until(sm) {
+        height: 30px;
+        width: 30px;
+        border-radius: 0.25rem;
+      }
     }
   }
 
-  // topic activity, avatar, text
+  .dot-separator {
+    width: 0.25em;
+    height: 0.25em;
+    background-color: var(--primary-500);
+    border-radius: 100%;
+    margin-inline: 0.25em;
+  }
+
+  // topic activity, icon, text
   .topic-activity-data {
+    @include ellipsis;
     grid-area: activity;
   }
 
   .topic-activity {
-    display: grid;
-    grid-template-columns: 20px auto auto auto;
+    display: flex;
     font-size: var(--font-down-1);
     height: 100%;
     align-items: center;
     gap: 0.25em;
   }
 
-  .topic-activity__user .avatar {
-    width: 20px;
-    height: 20px;
-    border-radius: 4px;
-  }
-
-  .topic-activity__user {
-    height: 20px;
-    width: 20px;
-    border-radius: 4px;
+  .topic-activity__type {
+    border-radius: 0.25rem;
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: var(--primary-low);
   }
 
   .topic-activity__username {
+    @include ellipsis;
     margin-left: 0.25em;
-    text-wrap: nowrap;
   }
 
-  @include breakpoint(mobile-extra-large) {
-    .topic-activity__username {
-      display: none;
-    }
-
-    .topic-activity__reason {
-      margin-left: 0.25em;
-    }
-  }
-
-  .topic-activity.--updated .topic-activity__reason {
-    margin-left: 0.25em;
+  // timestamp
+  td.activity .post-activity {
+    grid-area: activity;
+    font-size: var(--font-down-1);
+    color: var(--primary-500);
+    margin-left: auto;
+    padding: 0;
   }
 
   // status
@@ -206,15 +187,23 @@
     margin-left: auto;
     display: flex;
     flex-direction: row;
-    gap: 4px;
+    gap: 0.25em;
     align-items: center;
-    padding: 0 6px;
+    padding: 0.25em 0.5rem;
     font-size: var(--font-down-2);
     font-weight: 600;
-    border-radius: var(--d-border-radius);
+    border-radius: 0.25rem;
     border: 1px solid var(--status-color);
     color: var(--status-color);
     width: min-content;
+
+    &.--pinned {
+      --status-color: var(--primary-500);
+    }
+
+    &.--hot {
+      --status-color: #e45735;
+    }
 
     @include breakpoint("large", min-width) {
       position: absolute;
@@ -231,28 +220,12 @@
     }
   }
 
-  .topic-status-card.--pinned {
-    --status-color: var(--primary-500);
-  }
-
-  .topic-status-card.--hot {
-    --status-color: #e45735;
-  }
-
   .link-top-line .event-date {
     margin-left: 0.5em;
     font-size: var(--font-down-3);
   }
 
-  td.main-link a.topic-status {
-    display: none;
-  }
-
   .topic-list-data {
-    padding: 0;
-  }
-
-  td.main-link .link-top-line a.raw-topic-link {
     padding: 0;
   }
 
@@ -268,33 +241,13 @@
     min-width: unset;
   }
 
-  .badge-notification.new-topic::before {
-    display: none;
-  }
-
-  // timestamp
-  td.activity .post-activity {
-    grid-area: activity;
-    font-size: var(--font-down-1);
-    color: var(--primary-500);
-    margin-left: auto;
-    padding: 0;
-  }
-
-  .link-bottom-line {
-    display: none;
-  }
-
-  // metadata
   // metadata - excerpt
-  .topic-excerpt,
-  td.main-link .link-bottom-line {
-    // grid-row: 3 / -1;
-    // grid-column: 1 / -3;
+  .topic-excerpt {
     grid-area: excerpt;
     margin: 0;
     padding: 0;
     font-size: var(--font-down-2);
+    width: 100%;
 
     .excerpt__contents {
       color: var(--primary-high);
@@ -306,31 +259,17 @@
     }
   }
 
-  td.topic-category-status-data {
-    display: contents;
-  }
-
-  td.topic-category-data {
-    grid-area: category;
-    display: flex;
-    justify-content: flex-end;
-
-    @include breakpoint(mobile-extra-large) {
-      justify-content: flex-start;
-    }
-  }
-
   td.topic-category-data .badge-category__wrapper,
   td.main-link .link-bottom-line .badge-category__wrapper {
-    border-radius: var(--d-border-radius);
-    padding: 3px 6px;
+    border-radius: 0.25rem;
+    padding: 0.25em 0.5rem;
     background-color: light-dark(
       oklch(from var(--category-badge-color) 97% calc(c * 0.3) h),
       oklch(from var(--category-badge-color) 45% calc(c * 0.5) h)
     );
 
     @include breakpoint(tablet) {
-      padding: 2px 6px;
+      padding: 0.25em 0.5rem;
       font-size: var(--font-down-2);
     }
 
@@ -370,6 +309,7 @@
     gap: 0.5em;
     align-items: center;
     color: var(--primary-500);
+    font-size: var(--font-down-1-rem);
 
     svg {
       color: var(--primary-600);

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -30,6 +30,7 @@
 }
 
 .topic-list-body .topic-list-item {
+  position: relative;
   background: var(--d-content-background);
   box-shadow: 0 0 12px 1px var(--topic-card-shadow);
   text-overflow: ellipsis;
@@ -72,8 +73,7 @@
   }
 
   &.selected {
-    box-shadow:
-      0 0 0 2px var(--accent-color),
+    box-shadow: 0 0 0 2px var(--accent-color),
       0 0 12px 1px var(--topic-card-shadow);
   }
 
@@ -229,7 +229,6 @@
   // status
   .topic-status-data {
     grid-area: status;
-    position: relative;
   }
 
   .topic-status-card {
@@ -239,10 +238,10 @@
     flex-direction: row;
     gap: 0.25em;
     align-items: center;
-    padding: 0.25em 0.5rem;
-    font-size: var(--font-down-2);
+    padding: 0.2em 0.5rem;
+    font-size: var(--font-down-3);
     font-weight: 600;
-    border-radius: 0.25rem;
+    border-radius: var(--d-border-radius);
     border: 1px solid var(--status-color);
     color: var(--status-color);
     width: min-content;
@@ -255,13 +254,12 @@
       --status-color: #e45735;
     }
 
-    @include breakpoint("large", min-width) {
+    @include viewport.from(lg) {
       position: absolute;
-      right: 0;
-      top: -20px;
+      right: 1rem;
+      top: 0;
+      transform: translateY(-45%);
       background-color: var(--d-content-background);
-      height: 20px;
-      font-size: var(--font-down-3);
     }
 
     svg {

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -32,24 +32,24 @@
   padding: 0.75em 1rem;
   border: 1px solid var(--primary-300);
   display: grid;
-  grid-template-columns: 20px min-content min-content auto min-content;
+  grid-template-columns: min-content min-content min-content auto min-content;
   grid-template-rows: auto minmax(20px, auto);
   grid-template-areas:
-    ". . . . status"
-    "activity . . likes-replies category";
-  grid-column-gap: 12px;
-  grid-row-gap: 8px;
+    "creator title title title status"
+    "creator category activity likes-replies .";
+  grid-column-gap: 0.75rem;
+  grid-row-gap: 0.5rem;
   border-radius: var(--d-border-radius);
   cursor: pointer;
 
   td.main-link .link-top-line {
-    grid-row: 1/2;
-    grid-column: 1/-1;
+    // grid-column: 3/-1;
+    grid-area: title;
     font-weight: 500;
   }
 
   &.--has-status-card td.main-link .link-top-line {
-    grid-column: 1/-2;
+    // grid-column: 3/-2;
   }
 
   @include breakpoint(extra-large) {
@@ -78,18 +78,19 @@
 
   &.excerpt-expanded {
     grid-template-columns: 20px auto auto min-content min-content;
-    grid-template-rows: auto auto auto;
+    grid-template-rows: auto auto auto auto;
     grid-template-areas:
-      ". . . . status"
+      "category category . . status"
+      "title title title title title"
       "activity . . . ."
-      "excerpt excerpt excerpt likes-replies category";
+      "excerpt excerpt excerpt excerpy likes-replies";
 
-    @include breakpoint(extra-large) {
-      grid-template-areas:
-        ". . . . status"
-        "activity . . . ."
-        "excerpt excerpt excerpt likes-replies category";
-    }
+    // @include breakpoint(extra-large) {
+    //   grid-template-areas:
+    //     "category category . . status"
+    //     "activity . . . ."
+    //     "excerpt excerpt excerpt excerpt likes-replies";
+    // }
 
     @include breakpoint(mobile-extra-large) {
       grid-template-rows: auto auto auto;
@@ -132,6 +133,17 @@
 
   td.num.posts a {
     padding: 0;
+  }
+
+  //OP avatar
+  .topic-creator {
+    grid-area: creator;
+
+    .avatar {
+      height: 50px;
+      width: 50px;
+      border-radius: var(--d-border-radius);
+    }
   }
 
   // topic activity, avatar, text
@@ -277,9 +289,11 @@
   // metadata - excerpt
   .topic-excerpt,
   td.main-link .link-bottom-line {
-    grid-row: 3 / -1;
-    grid-column: 1 / -3;
+    // grid-row: 3 / -1;
+    // grid-column: 1 / -3;
+    grid-area: excerpt;
     margin: 0;
+    padding: 0;
     font-size: var(--font-down-2);
 
     .excerpt__contents {
@@ -375,8 +389,7 @@
   }
 
   &.selected {
-    box-shadow:
-      0 0 0 2px var(--accent-color),
+    box-shadow: 0 0 0 2px var(--accent-color),
       0 0 12px 1px var(--topic-card-shadow);
   }
 }

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -72,7 +72,8 @@
   }
 
   &.selected {
-    box-shadow: 0 0 0 2px var(--accent-color),
+    box-shadow:
+      0 0 0 2px var(--accent-color),
       0 0 12px 1px var(--topic-card-shadow);
   }
 

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -30,6 +30,8 @@
 }
 
 .topic-list-body .topic-list-item {
+  background: var(--d-content-background);
+  box-shadow: 0 0 12px 1px var(--topic-card-shadow);
   text-overflow: ellipsis;
   padding: 0.75em 1rem;
   border: 1px solid var(--primary-300);
@@ -55,6 +57,18 @@
     border-radius: 0;
   }
 
+  &:hover {
+    .discourse-no-touch & {
+      border-color: var(--accent-color);
+      background: var(--d-content-background);
+    }
+  }
+
+  &.selected {
+    box-shadow: 0 0 0 2px var(--accent-color),
+      0 0 12px 1px var(--topic-card-shadow);
+  }
+
   &.excerpt-expanded {
     @include viewport.until(sm) {
       .topic-excerpt,
@@ -77,10 +91,6 @@
         "creator category activity ."
         "creator excerpt excerpt likes-replies";
     }
-  }
-
-  .badge-category__wrapper {
-    height: min-content;
   }
 
   .link-top-line {
@@ -114,6 +124,27 @@
   .topic-category-data {
     grid-area: category;
     display: flex;
+  }
+
+  .badge-category__wrapper {
+    border-radius: 0.25rem;
+    padding: 0.25em 0.5rem;
+    background-color: light-dark(
+      oklch(from var(--category-badge-color) 97% calc(c * 0.3) h),
+      oklch(from var(--category-badge-color) 45% calc(c * 0.5) h)
+    );
+
+    @include breakpoint(tablet) {
+      padding: 0.25em 0.5rem;
+      font-size: var(--font-down-2);
+    }
+
+    .badge-category__name {
+      color: light-dark(
+        oklch(from var(--category-badge-color) 20% calc(c * 1) h),
+        oklch(from var(--category-badge-color) 100% calc(c * 0.9) h)
+      );
+    }
   }
 
   //OP avatar
@@ -259,28 +290,6 @@
     }
   }
 
-  td.topic-category-data .badge-category__wrapper,
-  td.main-link .link-bottom-line .badge-category__wrapper {
-    border-radius: 0.25rem;
-    padding: 0.25em 0.5rem;
-    background-color: light-dark(
-      oklch(from var(--category-badge-color) 97% calc(c * 0.3) h),
-      oklch(from var(--category-badge-color) 45% calc(c * 0.5) h)
-    );
-
-    @include breakpoint(tablet) {
-      padding: 0.25em 0.5rem;
-      font-size: var(--font-down-2);
-    }
-
-    .badge-category__name {
-      color: light-dark(
-        oklch(from var(--category-badge-color) 20% calc(c * 1) h),
-        oklch(from var(--category-badge-color) 100% calc(c * 0.9) h)
-      );
-    }
-  }
-
   td.main-link .discourse-tags {
     display: none;
   }
@@ -314,23 +323,6 @@
     svg {
       color: var(--primary-600);
     }
-  }
-}
-
-.topic-list-item {
-  background: var(--d-content-background);
-  box-shadow: 0 0 12px 1px var(--topic-card-shadow);
-
-  &:hover {
-    .discourse-no-touch & {
-      border-color: var(--accent-color);
-      background: var(--d-content-background);
-    }
-  }
-
-  &.selected {
-    box-shadow: 0 0 0 2px var(--accent-color),
-      0 0 12px 1px var(--topic-card-shadow);
   }
 }
 

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -82,9 +82,6 @@
       .link-bottom-line {
         display: none;
       }
-
-      .bulk-select-enabled & {
-      }
     }
 
     @include viewport.from(sm) {
@@ -101,7 +98,7 @@
       }
     }
 
-    //when there is enough space, excerpt can be next to likes-replies
+    // when there is enough space, excerpt can be next to likes-replies
     @include viewport.from(lg) {
       grid-template-areas:
         "creator title title status"
@@ -135,7 +132,7 @@
     padding: 0;
   }
 
-  //display:nones
+  // display:nones
   td.main-link a.topic-status,
   .link-bottom-line,
   .badge-notification.new-topic::before {
@@ -168,7 +165,7 @@
     }
   }
 
-  //OP avatar
+  // OP avatar
   .topic-creator {
     grid-area: creator;
 

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -45,6 +45,13 @@
   border-radius: var(--d-border-radius);
   cursor: pointer;
 
+  .bulk-select-enabled & {
+    grid-template-columns: min-content min-content min-content auto min-content;
+    grid-template-areas:
+      "bulk-select creator title title status"
+      "bulk-select creator category activity likes-replies";
+  }
+
   @include viewport.until(sm) {
     grid-template-areas:
       "category category category status"
@@ -75,6 +82,9 @@
       .link-bottom-line {
         display: none;
       }
+
+      .bulk-select-enabled & {
+      }
     }
 
     @include viewport.from(sm) {
@@ -82,6 +92,13 @@
         "creator title title status"
         "creator category activity likes-replies "
         "creator excerpt excerpt excerpt";
+
+      .bulk-select-enabled & {
+        grid-template-areas:
+          "bulk-select creator title title status"
+          "bulk-select creator category activity likes-replies "
+          " bulk-select creator excerpt excerpt excerpt";
+      }
     }
 
     //when there is enough space, excerpt can be next to likes-replies
@@ -98,6 +115,10 @@
     font-weight: 500;
     display: flex;
     align-items: center;
+
+    .title {
+      padding: 0;
+    }
   }
 
   // display contents
@@ -322,6 +343,22 @@
 
     svg {
       color: var(--primary-600);
+    }
+  }
+
+  .bulk-select {
+    grid-area: bulk-select;
+    padding: 0;
+    margin: 0;
+    align-self: flex-start;
+    justify-self: center;
+
+    label {
+      margin: 0;
+    }
+
+    &th {
+      display: none;
     }
   }
 }
@@ -564,13 +601,16 @@ body.user-messages-page {
     grid-template-rows: auto auto;
 
     &:hover {
-      background-color: var(--primary-low);
-      border-color: var(--primary-200);
+      .discourse-no-touch & {
+        background-color: var(--primary-low);
+        border-color: var(--primary-200);
+      }
     }
 
     td.topic-category-data,
     td.topic-likes-replies-data,
-    td.topic-status-data {
+    td.topic-status-data,
+    td.topic-creator {
       display: none;
     }
 
@@ -599,73 +639,6 @@ body.user-messages-page {
         border-radius: 4px;
         background-color: var(--primary-low);
       }
-    }
-  }
-}
-
-// Bulk select
-.bulk-select-enabled .topic-list-body .topic-list-item {
-  grid-template-areas:
-    "bulk-select . . . status"
-    "bulk-select activity activity . category";
-
-  @include breakpoint(large) {
-    grid-template-areas:
-      "bulk-select . . . status"
-      "bulk-select activity activity . category";
-  }
-
-  @include breakpoint(mobile-extra-large) {
-    grid-template-areas:
-      "bulk-select category . . .  status"
-      "bulk-select . . . . ."
-      "bulk-select activity activity . . .";
-
-    td.main-link .link-top-line,
-    &.--has-status-card td.main-link .link-top-line {
-      grid-column: 2/-1;
-      grid-row: 2;
-      font-weight: 500;
-    }
-  }
-
-  td.topic-likes-replies-data {
-    display: none;
-  }
-
-  td.main-link .link-top-line,
-  &.--has-status-card td.main-link .link-top-line {
-    grid-column: 2/-1;
-    font-weight: 500;
-  }
-
-  .topic-excerpt {
-    grid-area: excerpt;
-    margin: 0;
-  }
-
-  &.excerpt-expanded {
-    grid-template-areas:
-      "bulk-select . . . status" "bulk-select activity . . ."
-      "bulk-select excerpt excerpt excerpt category";
-
-    @include breakpoint(mobile-extra-large) {
-      grid-template-areas:
-        "bulk-select category . . .  status"
-        "bulk-select . . . . ."
-        "bulk-select activity activity . . .";
-    }
-  }
-
-  .bulk-select {
-    grid-area: bulk-select;
-    padding: 0;
-    margin: 0;
-    align-self: center;
-    justify-self: center;
-
-    label {
-      margin: 0;
     }
   }
 }

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -350,8 +350,12 @@
     grid-area: bulk-select;
     padding: 0;
     margin: 0;
-    align-self: flex-start;
+    align-self: center;
     justify-self: center;
+
+    @include viewport.until(sm) {
+      align-self: flex-start;
+    }
 
     label {
       margin: 0;

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -72,8 +72,7 @@
   }
 
   &.selected {
-    box-shadow:
-      0 0 0 2px var(--accent-color),
+    box-shadow: 0 0 0 2px var(--accent-color),
       0 0 12px 1px var(--topic-card-shadow);
   }
 
@@ -167,7 +166,7 @@
   }
 
   // OP avatar
-  .topic-creator {
+  .topic-creator-data {
     grid-area: creator;
 
     .avatar {
@@ -612,7 +611,7 @@ body.user-messages-page {
     td.topic-category-data,
     td.topic-likes-replies-data,
     td.topic-status-data,
-    td.topic-creator {
+    td.topic-creator-data {
       display: none;
     }
 

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -73,7 +73,8 @@
   }
 
   &.selected {
-    box-shadow: 0 0 0 2px var(--accent-color),
+    box-shadow:
+      0 0 0 2px var(--accent-color),
       0 0 12px 1px var(--topic-card-shadow);
   }
 

--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -146,7 +146,7 @@
   }
 
   .badge-category__wrapper {
-    border-radius: 0.25rem;
+    border-radius: var(--d-border-radius);
     padding: 0.25em 0.5rem;
     background-color: light-dark(
       oklch(from var(--category-badge-color) 97% calc(c * 0.3) h),

--- a/spec/system/horizon_high_level_spec.rb
+++ b/spec/system/horizon_high_level_spec.rb
@@ -39,6 +39,7 @@ describe "Horizon theme | High level", type: :system do
         "topic-status-data",
         "topic-category-data",
         "topic-likes-replies-data",
+        "topic-creator-data",
         "topic-activity-data",
       ],
     )


### PR DESCRIPTION
This is the second iteration on the topic card design, in which we bring back the OP and change the layout.

**Changes**:
* Show OP avatar
* Remove activity avatar and replace by reply icon
* Remove activity icon background
* Move category tag to top left
* Replace long activity copy ("…replied at…") with dot separator
* Change date formatting to `tiny`
* Adjust bulk select styling to new layout + align checkbox to top on mobile VS keep centred on desktop

   * Why: On desktop, the avatar is taking 2 lines (usually) and aligning the checkbox vertically looks nice. Exception for excerpts, but since that's only available for pinned topics atm that's a low occurrence.  On mobile, the topic card is 3 lines, with a smaller avatar, which makes the checkbox "float" around a bit when centred. Hence aligning it to the top, which for solid avatars aligns nicely too.

* CSS refactor: grid, breakpoints

Messages/bookmarks have not been changed.

| Description | Visual |
|--------|--------|
| Large topic list | ![CleanShot 2025-06-02 at 17 37 35@2x](https://github.com/user-attachments/assets/f232058e-dbf6-4689-abe3-65970464a3e3)|
| Large bulk edit | ![CleanShot 2025-06-02 at 17 37 17@2x](https://github.com/user-attachments/assets/03d86b5f-d62b-4449-9c0b-452ceb8be60c) |
| Medium topic list | ![CleanShot 2025-06-02 at 17 39 01@2x](https://github.com/user-attachments/assets/80739641-cf8f-4095-938f-9781cac57a7d) |
| Medium bulk edit | ![CleanShot 2025-06-02 at 17 39 24@2x](https://github.com/user-attachments/assets/6e9045af-734a-4f3f-830a-e03a2f06fdd8) |
| Small topic list | ![CleanShot 2025-06-02 at 17 39 44@2x](https://github.com/user-attachments/assets/eeca80bc-6863-4026-8f19-b1b5cf6848f3) |
| Small bulk edit | ![CleanShot 2025-06-02 at 17 40 00@2x](https://github.com/user-attachments/assets/cde7be08-cde2-4ff2-b81b-328d3d7be848) |
| Messages page (remains unchanged) | ![CleanShot 2025-06-02 at 17 20 37@2x](https://github.com/user-attachments/assets/6512bfe9-a699-4c67-b709-166540ee6fde) | 
| Bookmark page (remains unchanged) | ![CleanShot 2025-06-02 at 17 21 01@2x](https://github.com/user-attachments/assets/f8f43638-e911-49cb-a0d5-ebcb51ccfba4) | 