### PR TITLE
UX: fix mobile timeline in PWA

### DIFF
--- a/scss/topic.scss
+++ b/scss/topic.scss
@@ -6,14 +6,6 @@
   }
 }
 
-.container.posts .topic-navigation:not(.with-topic-progress) {
-  // super fragile because new sticky topic title doesn't have a calculated value (= 53px with this font and size but…)
-  top: calc(
-    var(--header-offset, 60px) + 53px + calc(var(--spacing-block-l) * 2)
-  );
-  z-index: 300;
-}
-
 .timeline-container .topic-timeline {
   min-width: unset; // why we have this?
 


### PR DESCRIPTION
Since the title is no longer sticky, I think we can drop all of this @jordanvidrine? The z-index puts the timeline behind the footer controls in the PWA

Before:
![image](https://github.com/user-attachments/assets/af4c9adf-6f2c-4f3f-9ac3-6defb7294123)

After:
![image](https://github.com/user-attachments/assets/721f8181-170e-49f1-b681-15e5c101a395)
