### PR TITLE
UX: Remove unused line & fix ipad safari browser

### DIFF
--- a/scss/box-view.scss
+++ b/scss/box-view.scss
@@ -40,7 +40,6 @@
   margin: 0;
   padding: 0;
   position: relative;
-  container: content-width / inline-size;
 
   @include breakpoint(medium) {
     display: none;


### PR DESCRIPTION
This line removal solves two purposes:
- it was not needed
- its removal fixes a rendering bug in safari on ipad