### PR TITLE
UX: Unhide topics footer-message

### DIFF
--- a/scss/hiddenstuff.scss
+++ b/scss/hiddenstuff.scss
@@ -2,8 +2,6 @@
 .list-controls #create-topic,
 .notifications-button-footer .reason .text,
 .pinned-button .reason .text,
-.more-topics__browse-more,
-// footer-message might cause issues, not sure what possible stuff can be in there, but the general idea is to hide it bcs having an ugly H3 (what?) CTA at the bottom is just… ugly imo
-.footer-message {
+.more-topics__browse-more {
   display: none;
 }


### PR DESCRIPTION
This needs to be unhidden so the changes in the following core PR are visible in horizon:

https://github.com/discourse/discourse/pull/32669