### PR TITLE
UX: remove default select state for keyboard nav on topic cards

### DIFF
--- a/scss/topic-cards.scss
+++ b/scss/topic-cards.scss
@@ -631,6 +631,12 @@
   }
 }
 
+// bulk-select overrule for j/k nav
+.topic-list tr.selected td:first-of-type,
+.topic-list-item.selected td:first-of-type {
+  box-shadow: none;
+}
+
 // User Messages
 body.user-messages-page {
   .topic-list-body {


### PR DESCRIPTION
The left-border select state when using keyboard navigation is already overruled in Horizon, but when bulk-select is enabled, this still showed up:

![CleanShot 2025-06-18 at 12 28 16@2x](https://github.com/user-attachments/assets/e1b9bfbc-aceb-429a-8890-fb56f7e12048)

Fixed:
![CleanShot 2025-06-18 at 12 29 09@2x](https://github.com/user-attachments/assets/40572de6-a316-4f7b-8786-9040f513b6c8)

