### PR TITLE
UX: hide welcome banner

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -98,6 +98,10 @@ body:not(.has-full-page-chat, .wizard) {
   }
 }
 
+.welcome-banner {
+  display: none;
+}
+
 #list-area {
   .show-more.has-topics {
     @include viewport.from(lg) {


### PR DESCRIPTION
Until we move forward with the search-banner on mobile, the welcome-message feels out of place. Hiding it for now.